### PR TITLE
Add new PUL/CUL ptypes 108, 107

### DIFF
--- a/data/patron_types.csv
+++ b/data/patron_types.csv
@@ -106,8 +106,8 @@ ptype code,Sierra label
 104,
 105,
 106,NYPL Department
-107,
-108,
+107,Partner Card - Columbia
+108,Partner Card - Princeton
 109,
 110,
 111,


### PR DESCRIPTION
Added ptypes 107 and 108 to the ptype lookup table. 

These 2 new ptypes were added to Sierra recently and will impact circ trans analysis. I've notified Daphna and Tony of this change.


